### PR TITLE
chore: update @emeraldcoder/riichi-ui-css version to "workspace:*"

### DIFF
--- a/packages/riichi-ui-vue/package.json
+++ b/packages/riichi-ui-vue/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@vue/compiler-core": "^3.0.0",
-    "@emeraldcoder/riichi-ui-css": "*",
+    "@emeraldcoder/riichi-ui-css": "workspace:*",
     "@storybook/addon-essentials": "^7.0.0",
     "@storybook/addon-interactions": "^7.0.0",
     "@storybook/addon-links": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
   packages/riichi-ui-vue:
     devDependencies:
       '@emeraldcoder/riichi-ui-css':
-        specifier: '*'
+        specifier: 'workspace:*'
         version: link:../riichi-ui-css
       '@storybook/addon-essentials':
         specifier: ^7.0.0


### PR DESCRIPTION
PNPM seems to works better when building packages with the recursive option